### PR TITLE
(#5) Disable 'allow_unconfigured' by default

### DIFF
--- a/.plugin.yaml
+++ b/.plugin.yaml
@@ -1,4 +1,4 @@
 mcollective_util_actionpolicy::server_config:
-  allow_unconfigured: 1
+  allow_unconfigured: 0
   enable_default: 0
 


### PR DESCRIPTION
By default, we do not want users to be able to do anything with an agent if no policy is in place for this agent.